### PR TITLE
Make Worker Timeout Configurable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -507,6 +507,12 @@ PAPERLESS_THREADS_PER_WORKER=<num>
     PAPERLESS_THREADS_PER_WORKER automatically.
 
 
+PAPERLESS_WORKER_TIMEOUT=<num>
+    Machines with few cores or weak ones might not be able to finish OCR on
+    large documents within the default 1800 seconds. So extending this timeout
+    may prove be useful on weak hardware setups.
+
+
 PAPERLESS_TIME_ZONE=<timezone>
     Set the time zone here.
     See https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-TIME_ZONE

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -422,7 +422,7 @@ Q_CLUSTER = {
     'catch_up': False,
     'recycle': 1,
     'retry': 1800,
-    'timeout': 1800,
+    'timeout': int(os.getenv("PAPERLESS_WORKER_TIMEOUT", 1800)),
     'workers': TASK_WORKERS,
     'redis': os.getenv("PAPERLESS_REDIS", "redis://localhost:6379")
 }


### PR DESCRIPTION
- defaults to 1800 seconds
- can be configured through environment for systems with weaker CPUs
- description added to documentation